### PR TITLE
WAFのChallengeが有効になっているときのMisskey Webの問題を修正

### DIFF
--- a/packages/backend/src/server/web/bios.js
+++ b/packages/backend/src/server/web/bios.js
@@ -18,7 +18,8 @@ window.onload = async () => {
 			window.fetch(endpoint.indexOf('://') > -1 ? endpoint : `/api/${endpoint}`, {
 				method: 'POST',
 				body: JSON.stringify(data),
-				credentials: 'omit',
+				credentials: 'same-origin',
+				mode: 'same-origin',
 				cache: 'no-cache'
 			}).then(async (res) => {
 				const body = res.status === 204 ? null : await res.json();

--- a/packages/backend/src/server/web/boot.js
+++ b/packages/backend/src/server/web/boot.js
@@ -50,7 +50,8 @@
 		const metaRes = await window.fetch('/api/meta', {
 			method: 'POST',
 			body: JSON.stringify({}),
-			credentials: 'omit',
+			credentials: 'same-origin',
+			mode: 'same-origin',
 			cache: 'no-cache',
 			headers: {
 				'Content-Type': 'application/json',

--- a/packages/backend/src/server/web/cli.js
+++ b/packages/backend/src/server/web/cli.js
@@ -21,7 +21,8 @@ window.onload = async () => {
 				},
 				method: 'POST',
 				body: JSON.stringify(data),
-				credentials: 'omit',
+				credentials: 'same-origin',
+				mode: 'same-origin',
 				cache: 'no-cache'
 			}).then(async (res) => {
 				const body = res.status === 204 ? null : await res.json();

--- a/packages/backend/src/server/web/views/base.pug
+++ b/packages/backend/src/server/web/views/base.pug
@@ -30,7 +30,7 @@ html
 		meta(name='viewport' content='width=device-width, initial-scale=1')
 		link(rel='icon' href= icon || '/favicon.ico')
 		link(rel='apple-touch-icon' href= appleTouchIcon || '/apple-touch-icon.png')
-		link(rel='manifest' href='/manifest.json')
+		link(rel='manifest' href='/manifest.json' crossorigin="use-credentials")
 		link(rel='search' type='application/opensearchdescription+xml' title=(title || "Misskey") href=`${url}/opensearch.xml`)
 		link(rel='prefetch' href=serverErrorImageUrl)
 		link(rel='prefetch' href=infoImageUrl)

--- a/packages/frontend/src/scripts/misskey-api.ts
+++ b/packages/frontend/src/scripts/misskey-api.ts
@@ -37,7 +37,8 @@ export function misskeyApi<
 		window.fetch(`${apiUrl}/${endpoint}`, {
 			method: 'POST',
 			body: JSON.stringify(data),
-			credentials: 'omit',
+			credentials: 'same-origin',
+			mode: 'same-origin',
 			cache: 'no-cache',
 			headers: {
 				'Content-Type': 'application/json',
@@ -83,7 +84,8 @@ export function misskeyApiGet<
 		// Send request
 		window.fetch(`${apiUrl}/${endpoint}?${query}`, {
 			method: 'GET',
-			credentials: 'omit',
+			credentials: 'same-origin',
+			mode: 'same-origin',
 			cache: 'default',
 		}).then(async (res) => {
 			const body = res.status === 204 ? null : await res.json();


### PR DESCRIPTION
## What
- link要素からmanifest.jsonにアクセスする場合、認証情報を送信するように
- misskeyApi, misskeyApiGetなどでAPIにfetchでアクセスする場合、同一オリジンのみを対象とし、同一オリジンの場合のみ認証情報を送信するように
## Why
- manifest.jsonの取得（link要素）やfetchでAPIにアクセスするときに認証情報を送信していないので、WAFのChallengeをパスしてもこれらのリソースにアクセスできず、Misskey Webが利用できない