### PR TITLE
サーバー情報に関係するAPIの修正

### DIFF
--- a/packages/backend/src/daemons/ServerStatsService.ts
+++ b/packages/backend/src/daemons/ServerStatsService.ts
@@ -13,7 +13,7 @@ import type { OnApplicationShutdown } from '@nestjs/common';
 
 const ev = new Xev();
 
-const interval = 2000;
+const interval = 10000;
 
 const roundCpu = (num: number) => Math.round(num * 1000) / 1000;
 const round = (num: number) => Math.round(num * 10) / 10;

--- a/packages/backend/src/server/api/endpoints/server-info.ts
+++ b/packages/backend/src/server/api/endpoints/server-info.ts
@@ -8,11 +8,12 @@ import si from 'systeminformation';
 import { Injectable } from '@nestjs/common';
 import { Endpoint } from '@/server/api/endpoint-base.js';
 import { MetaService } from '@/core/MetaService.js';
+import { createHash } from 'node:crypto';
 
 export const meta = {
 	requireCredential: false,
 	allowGet: true,
-	cacheSec: 60 * 1,
+	cacheSec: 60 * 10,
 
 	tags: ['meta'],
 	res: {
@@ -95,7 +96,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 			const fsStats = await si.fsSize();
 
 			return {
-				machine: os.hostname(),
+				machine: createHash('md5').update(os.hostname()).digest('hex'),
 				cpu: {
 					model: os.cpus()[0].model,
 					cores: os.cpus().length,


### PR DESCRIPTION
## What
- server-infoのキャッシュ期間を1分から10分に
- server-infoでホスト名をそのまま返すのでなく、ホスト名のMD5ハッシュを返すように
- ストリーミングAPIのServerStatsの取得間隔を2秒から10秒に