### PR TITLE
オンラインユーザー数を隠す

### DIFF
--- a/packages/backend/src/server/api/endpoints/get-online-users-count.ts
+++ b/packages/backend/src/server/api/endpoints/get-online-users-count.ts
@@ -13,9 +13,9 @@ import { DI } from '@/di-symbols.js';
 export const meta = {
 	tags: ['meta'],
 
-	requireCredential: false,
-	allowGet: true,
-	cacheSec: 60 * 1,
+	requireCredential: true,
+	kind: 'read:account',
+
 	res: {
 		type: 'object',
 		optional: false, nullable: false,

--- a/packages/frontend/src/pages/admin/overview.stats.vue
+++ b/packages/frontend/src/pages/admin/overview.stats.vue
@@ -79,7 +79,7 @@ const fetching = ref(true);
 onMounted(async () => {
 	const [_stats, _onlineUsersCount] = await Promise.all([
 		misskeyApi('stats', {}),
-		misskeyApiGet('get-online-users-count').then(res => res.count),
+		misskeyApi('get-online-users-count').then(res => res.count),
 	]);
 	stats.value = _stats;
 	onlineUsersCount.value = _onlineUsersCount;

--- a/packages/frontend/src/widgets/WidgetOnlineUsers.vue
+++ b/packages/frontend/src/widgets/WidgetOnlineUsers.vue
@@ -45,7 +45,7 @@ const { widgetProps, configure } = useWidgetPropsManager(name,
 const onlineUsersCount = ref(0);
 
 const tick = () => {
-	misskeyApiGet('get-online-users-count').then(res => {
+	misskeyApi('get-online-users-count').then(res => {
 		onlineUsersCount.value = res.count;
 	});
 };


### PR DESCRIPTION
## What
- オンラインユーザー数を取得するエンドポイント (get-online-users-count)をクレデンシャル必須に
- 該当のエンドポイントの呼び出しをmisskeyApiGetからmisskeyApiに変更