### PR TITLE
ユーザーのPVを見られるのを本人とモデレーターのみに

### DIFF
--- a/packages/backend/src/server/api/endpoints/charts/user/pv.ts
+++ b/packages/backend/src/server/api/endpoints/charts/user/pv.ts
@@ -3,19 +3,38 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { getJsonSchema } from '@/core/chart/core.js';
 import { Endpoint } from '@/server/api/endpoint-base.js';
 import PerUserPvChart from '@/core/chart/charts/per-user-pv.js';
 import { schema } from '@/core/chart/charts/entities/per-user-pv.js';
+import type { UsersRepository } from '@/models/_.js';
+import { DI } from '@/di-symbols.js';
+import { RoleService } from '@/core/RoleService.js';
+import { ApiError } from '../../../error.js';
 
 export const meta = {
 	tags: ['charts', 'users'],
 
 	res: getJsonSchema(schema),
 
-	allowGet: true,
-	cacheSec: 60 * 60,
+	requireCredential: true,
+
+	kind: 'read:account',
+
+	errors: {
+		noSuchUser: {
+			message: 'No such user.',
+			code: 'NO_SUCH_USER',
+			id: '3b4cc707-d0b3-493d-b722-85bae07eac17',
+		},
+
+		accessDenied: {
+			message: 'Access denied.',
+			code: 'ACCESS_DENIED',
+			id: '47954d96-c146-4f5a-b145-ffc5252b906c',
+		},
+	}
 } as const;
 
 export const paramDef = {
@@ -32,9 +51,23 @@ export const paramDef = {
 @Injectable()
 export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-disable-line import/no-default-export
 	constructor(
+		@Inject(DI.usersRepository)
+		private usersRepository: UsersRepository,
+
 		private perUserPvChart: PerUserPvChart,
+		private roleService: RoleService,
 	) {
 		super(meta, paramDef, async (ps, me) => {
+			const user = await this.usersRepository.findOneBy({ id: ps.userId });
+
+			if (user == null) {
+				throw new ApiError(meta.errors.noSuchUser);
+			}
+
+			if (!await this.roleService.isModerator(me) && (user.id !== me.id)) {
+				throw new ApiError(meta.errors.accessDenied);
+			}
+
 			return await this.perUserPvChart.getChart(ps.span, ps.limit, ps.offset ? new Date(ps.offset) : null, ps.userId);
 		});
 	}

--- a/packages/frontend/src/components/MkChart.vue
+++ b/packages/frontend/src/components/MkChart.vue
@@ -708,7 +708,7 @@ const fetchPerUserNotesChart = async (): Promise<typeof chartData> => {
 };
 
 const fetchPerUserPvChart = async (): Promise<typeof chartData> => {
-	const raw = await misskeyApiGet('charts/user/pv', { userId: props.args?.user?.id, limit: props.limit, span: props.span });
+	const raw = await misskeyApi('charts/user/pv', { userId: props.args?.user?.id, limit: props.limit, span: props.span });
 	return {
 		series: [{
 			name: 'Unique PV (user)',

--- a/packages/frontend/src/pages/user/activity.vue
+++ b/packages/frontend/src/pages/user/activity.vue
@@ -18,7 +18,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 			<template #header><i class="ti ti-users"></i> Following</template>
 			<XFollowing :user="user"/>
 		</MkFoldableSection>
-		<MkFoldableSection class="item">
+		<MkFoldableSection v-if="iAmModerator || $i?.id == user.id" class="item">
 			<template #header><i class="ti ti-eye"></i> PV</template>
 			<XPv :user="user"/>
 		</MkFoldableSection>
@@ -33,6 +33,7 @@ import XNotes from './activity.notes.vue';
 import XFollowing from './activity.following.vue';
 import MkFoldableSection from '@/components/MkFoldableSection.vue';
 import MkHeatmap from '@/components/MkHeatmap.vue';
+import { $i, iAmModerator } from '@/account.js';
 
 const props = defineProps<{
 	user: Misskey.entities.User;


### PR DESCRIPTION
## What
- ユーザーのPV（charts/user/pv）を見られるのを本人とモデレーターのみに限定する
- ユーザープロフィールのアクティビティタブのPV欄を条件に応じて隠す