### PR TITLE
すべての数値が0のときHeatmapの表示がおかしくなる問題を修正

### DIFF
--- a/packages/frontend/src/components/MkHeatmap.vue
+++ b/packages/frontend/src/components/MkHeatmap.vue
@@ -128,7 +128,7 @@ async function renderChart() {
 				backgroundColor(c) {
 					// @ts-expect-error TS(2339)
 					const value = c.dataset.data[c.dataIndex].v as number;
-					let a = (value - min) / max;
+					let a = max === 0 ? 0 : (value - min) / max;
 					if (value !== 0) { // 0でない限りは完全に不可視にはしない
 						a = Math.max(a, 0.05);
 					}


### PR DESCRIPTION
- すべての数値が0のときHeatmapの表示がおかしくなる問題の修正