### PR TITLE
ハイライトを隠す

### DIFF
--- a/packages/backend/src/server/api/endpoints/notes/featured.ts
+++ b/packages/backend/src/server/api/endpoints/notes/featured.ts
@@ -15,9 +15,9 @@ import { CacheService } from '@/core/CacheService.js';
 export const meta = {
 	tags: ['notes'],
 
-	requireCredential: false,
-	allowGet: true,
-	cacheSec: 3600,
+	requireCredential: true,
+
+	kind: 'read:account',
 
 	res: {
 		type: 'array',

--- a/packages/backend/src/server/api/endpoints/users.ts
+++ b/packages/backend/src/server/api/endpoints/users.ts
@@ -9,6 +9,7 @@ import { Endpoint } from '@/server/api/endpoint-base.js';
 import { QueryService } from '@/core/QueryService.js';
 import { UserEntityService } from '@/core/entities/UserEntityService.js';
 import { DI } from '@/di-symbols.js';
+import { ApiError } from '../error.js';
 
 export const meta = {
 	tags: ['users'],
@@ -22,6 +23,14 @@ export const meta = {
 			type: 'object',
 			optional: false, nullable: false,
 			ref: 'UserDetailed',
+		},
+	},
+
+	errors: {
+		accessDenied: {
+			message: 'Access denied.',
+			code: 'ACCESS_DENIED',
+			id: '1f52fa0c-0873-436b-9888-df7ca85679d0',
 		},
 	},
 } as const;
@@ -54,6 +63,10 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 		private queryService: QueryService,
 	) {
 		super(meta, paramDef, async (ps, me) => {
+			if (me == null && ps.origin !== 'local') {
+				throw new ApiError(meta.errors.accessDenied);
+			}
+
 			const query = this.usersRepository.createQueryBuilder('user')
 				.where('user.isExplorable = TRUE')
 				.andWhere('user.isSuspended = FALSE');

--- a/packages/frontend/src/pages/explore.users.vue
+++ b/packages/frontend/src/pages/explore.users.vue
@@ -29,7 +29,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 			</MkFoldableSection>
 		</template>
 	</div>
-	<div v-else>
+	<div v-else-if="$i">
 		<MkFoldableSection ref="tagsEl" :foldable="true" :expanded="false" class="_margin">
 			<template #header><i class="ti ti-hash ti-fw" style="margin-right: 0.5em;"></i>{{ i18n.ts.popularTags }}</template>
 
@@ -59,6 +59,12 @@ SPDX-License-Identifier: AGPL-3.0-only
 			</MkFoldableSection>
 		</template>
 	</div>
+	<div v-else>
+		<div class="_fullinfo">
+			<img :src="infoImageUrl" class="_ghost"/>
+			<div>{{ i18n.ts.nothing }}</div>
+		</div>
+	</div>
 </MkSpacer>
 </template>
 
@@ -70,6 +76,8 @@ import MkFoldableSection from '@/components/MkFoldableSection.vue';
 import MkTab from '@/components/MkTab.vue';
 import { misskeyApi } from '@/scripts/misskey-api.js';
 import { i18n } from '@/i18n.js';
+import { $i } from '@/account.js';
+import { infoImageUrl } from '@/instance.js';
 
 const props = defineProps<{
 	tag?: string;

--- a/packages/frontend/src/pages/explore.vue
+++ b/packages/frontend/src/pages/explore.vue
@@ -35,7 +35,7 @@ const props = withDefaults(defineProps<{
 	tag?: string;
 	initialTab?: string;
 }>(), {
-	initialTab: 'users',
+	initialTab: $i ? 'featured' : 'users',
 });
 
 const tab = ref(props.initialTab);

--- a/packages/frontend/src/pages/explore.vue
+++ b/packages/frontend/src/pages/explore.vue
@@ -7,13 +7,13 @@ SPDX-License-Identifier: AGPL-3.0-only
 <MkStickyContainer>
 	<template #header><MkPageHeader v-model:tab="tab" :actions="headerActions" :tabs="headerTabs"/></template>
 	<MkHorizontalSwipe v-model:tab="tab" :tabs="headerTabs">
-		<div v-if="tab === 'featured'" key="featured">
+		<div v-if="tab === 'featured' && $i" key="featured">
 			<XFeatured/>
 		</div>
 		<div v-else-if="tab === 'users'" key="users">
 			<XUsers/>
 		</div>
-		<div v-else-if="tab === 'roles'" key="roles">
+		<div v-else-if="tab === 'roles' && $i" key="roles">
 			<XRoles/>
 		</div>
 	</MkHorizontalSwipe>
@@ -29,12 +29,13 @@ import MkFoldableSection from '@/components/MkFoldableSection.vue';
 import MkHorizontalSwipe from '@/components/MkHorizontalSwipe.vue';
 import { definePageMetadata } from '@/scripts/page-metadata.js';
 import { i18n } from '@/i18n.js';
+import { $i } from '@/account.js';
 
 const props = withDefaults(defineProps<{
 	tag?: string;
 	initialTab?: string;
 }>(), {
-	initialTab: 'featured',
+	initialTab: 'users',
 });
 
 const tab = ref(props.initialTab);
@@ -46,19 +47,19 @@ watch(() => props.tag, () => {
 
 const headerActions = computed(() => []);
 
-const headerTabs = computed(() => [{
+const headerTabs = computed(() => [...($i ? [{
 	key: 'featured',
 	icon: 'ti ti-bolt',
 	title: i18n.ts.featured,
-}, {
+}] : []), {
 	key: 'users',
 	icon: 'ti ti-users',
 	title: i18n.ts.users,
-}, {
+}, ...($i ? [{
 	key: 'roles',
 	icon: 'ti ti-badges',
 	title: i18n.ts.roles,
-}]);
+}] : [])]);
 
 definePageMetadata(() => ({
 	title: i18n.ts.explore,

--- a/packages/frontend/src/pages/welcome.timeline.vue
+++ b/packages/frontend/src/pages/welcome.timeline.vue
@@ -39,10 +39,6 @@ const notes = ref<Misskey.entities.Note[]>([]);
 const isScrolling = ref(false);
 const scrollEl = shallowRef<HTMLElement>();
 
-misskeyApiGet('notes/featured').then(_notes => {
-	notes.value = _notes;
-});
-
 onUpdated(() => {
 	if (!scrollEl.value) return;
 	const container = getScrollContainer(scrollEl.value);


### PR DESCRIPTION
## What
- ハイライトのノートの取得（notes/featured）をクレデンシャル必須に
- リモートの人気・最近投稿・最近発見ユーザーの取得をクレデンシャル必須に
- 非ログイン時に"#みつける"内のタブを隠す