### PR TITLE
TL取得のwithRenotesパラメータが適切に反映されるように

### DIFF
--- a/packages/backend/src/server/api/endpoints/notes/global-timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/global-timeline.ts
@@ -90,10 +90,11 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 
 			if (ps.withRenotes === false) {
 				query.andWhere(new Brackets(qb => {
-					qb.where('note.renoteId IS NULL');
+					qb.orWhere('note.renoteId IS NULL');
 					qb.orWhere(new Brackets(qb => {
-						qb.where('note.text IS NOT NULL');
+						qb.orWhere('note.text IS NOT NULL');
 						qb.orWhere('note.fileIds != \'{}\'');
+						qb.orWhere('note.hasPoll IS TRUE');
 					}));
 				}));
 			}

--- a/packages/backend/src/server/api/endpoints/notes/hybrid-timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/hybrid-timeline.ts
@@ -112,6 +112,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 					includeRenotedMyNotes: ps.includeRenotedMyNotes,
 					includeLocalRenotes: ps.includeLocalRenotes,
 					withFiles: ps.withFiles,
+					withRenotes: ps.withRenotes,
 					withReplies: ps.withReplies,
 				}, me);
 
@@ -160,6 +161,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 					includeRenotedMyNotes: ps.includeRenotedMyNotes,
 					includeLocalRenotes: ps.includeLocalRenotes,
 					withFiles: ps.withFiles,
+					withRenotes: ps.withRenotes,
 					withReplies: ps.withReplies,
 				}, me),
 			});
@@ -180,6 +182,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 		includeRenotedMyNotes: boolean,
 		includeLocalRenotes: boolean,
 		withFiles: boolean,
+		withRenotes: boolean,
 		withReplies: boolean,
 	}, me: MiLocalUser) {
 		const followees = await this.userFollowingService.getFollowees(me.id);
@@ -266,6 +269,17 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 
 		if (ps.withFiles) {
 			query.andWhere('note.fileIds != \'{}\'');
+		}
+
+		if (ps.withRenotes === false) {
+			query.andWhere(new Brackets(qb => {
+				qb.orWhere('note.renoteId IS NULL');
+				qb.orWhere(new Brackets(qb => {
+					qb.orWhere('note.text IS NOT NULL');
+					qb.orWhere('note.fileIds != \'{}\'');
+					qb.orWhere('note.hasPoll IS TRUE');
+				}));
+			}));
 		}
 		//#endregion
 

--- a/packages/backend/src/server/api/endpoints/notes/local-timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/local-timeline.ts
@@ -97,6 +97,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 					sinceId,
 					limit: ps.limit,
 					withFiles: ps.withFiles,
+					withRenotes: ps.withRenotes,
 					withReplies: ps.withReplies,
 				}, me);
 
@@ -128,6 +129,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 					sinceId,
 					limit,
 					withFiles: ps.withFiles,
+					withRenotes: ps.withRenotes,
 					withReplies: ps.withReplies,
 				}, me),
 			});
@@ -147,6 +149,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 		untilId: string | null,
 		limit: number,
 		withFiles: boolean,
+		withRenotes: boolean,
 		withReplies: boolean,
 	}, me: MiLocalUser | null) {
 		const query = this.queryService.makePaginationQuery(this.notesRepository.createQueryBuilder('note'),
@@ -165,6 +168,17 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 
 		if (ps.withFiles) {
 			query.andWhere('note.fileIds != \'{}\'');
+		}
+
+		if (ps.withRenotes === false) {
+			query.andWhere(new Brackets(qb => {
+				qb.orWhere('note.renoteId IS NULL');
+				qb.orWhere(new Brackets(qb => {
+					qb.orWhere('note.text IS NOT NULL');
+					qb.orWhere('note.fileIds != \'{}\'');
+					qb.orWhere('note.hasPoll IS TRUE');
+				}));
+			}));
 		}
 
 		if (!ps.withReplies) {

--- a/packages/backend/src/server/api/endpoints/notes/timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/timeline.ts
@@ -243,7 +243,14 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 		}
 
 		if (ps.withRenotes === false) {
-			query.andWhere('note.renoteId IS NULL');
+			query.andWhere(new Brackets(qb => {
+				qb.orWhere('note.renoteId IS NULL');
+				qb.orWhere(new Brackets(qb => {
+					qb.orWhere('note.text IS NOT NULL');
+					qb.orWhere('note.fileIds != \'{}\'');
+					qb.orWhere('note.hasPoll IS TRUE');
+				}));
+			}));
 		}
 		//#endregion
 

--- a/packages/backend/src/server/api/endpoints/notes/user-list-timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/user-list-timeline.ts
@@ -238,6 +238,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 				qb.orWhere(new Brackets(qb => {
 					qb.orWhere('note.text IS NOT NULL');
 					qb.orWhere('note.fileIds != \'{}\'');
+					qb.orWhere('note.hasPoll IS TRUE');
 				}));
 			}));
 		}

--- a/packages/backend/src/server/api/endpoints/users/notes.ts
+++ b/packages/backend/src/server/api/endpoints/users/notes.ts
@@ -194,7 +194,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 				qb.orWhere('note.renoteId IS NULL');
 				qb.orWhere('note.text IS NOT NULL');
 				qb.orWhere('note.fileIds != \'{}\'');
-				qb.orWhere('0 < (SELECT COUNT(*) FROM poll WHERE poll."noteId" = note.id)');
+				qb.orWhere('note.hasPoll IS TRUE');
 			}));
 		}
 

--- a/packages/backend/src/server/api/stream/channels/global-timeline.ts
+++ b/packages/backend/src/server/api/stream/channels/global-timeline.ts
@@ -59,7 +59,7 @@ class GlobalTimelineChannel extends Channel {
 			if (reply.userId !== this.user!.id && note.userId !== this.user!.id && reply.userId !== note.userId) return;
 		}
 
-		if (note.renote && note.text == null && (note.fileIds == null || note.fileIds.length === 0) && !this.withRenotes) return;
+		if (note.renote && note.text == null && (note.fileIds == null || note.fileIds.length === 0) && note.poll == null && !this.withRenotes) return;
 
 		// Ignore notes from instances the user has muted
 		if (isInstanceMuted(note, new Set<string>(this.userProfile?.mutedInstances ?? []))) return;

--- a/packages/backend/src/server/api/stream/channels/hybrid-timeline.ts
+++ b/packages/backend/src/server/api/stream/channels/hybrid-timeline.ts
@@ -85,7 +85,7 @@ class HybridTimelineChannel extends Channel {
 			}
 		}
 
-		if (note.renote && note.text == null && (note.fileIds == null || note.fileIds.length === 0) && !this.withRenotes) return;
+		if (note.renote && note.text == null && (note.fileIds == null || note.fileIds.length === 0) && note.poll == null && !this.withRenotes) return;
 
 		// 流れてきたNoteがミュートしているユーザーが関わるものだったら無視する
 		if (isUserRelated(note, this.userIdsWhoMeMuting)) return;

--- a/packages/backend/src/server/api/stream/channels/local-timeline.ts
+++ b/packages/backend/src/server/api/stream/channels/local-timeline.ts
@@ -61,7 +61,7 @@ class LocalTimelineChannel extends Channel {
 			if (reply.userId !== this.user.id && note.userId !== this.user.id && reply.userId !== note.userId) return;
 		}
 
-		if (note.renote && note.text == null && (note.fileIds == null || note.fileIds.length === 0) && !this.withRenotes) return;
+		if (note.renote && note.text == null && (note.fileIds == null || note.fileIds.length === 0) && note.poll == null && !this.withRenotes) return;
 
 		// 流れてきたNoteがミュートしているユーザーが関わるものだったら無視する
 		if (isUserRelated(note, this.userIdsWhoMeMuting)) return;

--- a/packages/backend/src/server/api/stream/channels/user-list.ts
+++ b/packages/backend/src/server/api/stream/channels/user-list.ts
@@ -106,7 +106,7 @@ class UserListChannel extends Channel {
 			}
 		}
 
-		if (note.renote && note.text == null && (note.fileIds == null || note.fileIds.length === 0) && !this.withRenotes) return;
+		if (note.renote && note.text == null && (note.fileIds == null || note.fileIds.length === 0) && note.poll == null && !this.withRenotes) return;
 
 		// 流れてきたNoteがミュートしているユーザーが関わるものだったら無視する
 		if (isUserRelated(note, this.userIdsWhoMeMuting)) return;


### PR DESCRIPTION
## What
- PostgreSQLからTLのノートを取得するときのリノートの判定を修正してwithRenotesパラメータが適切に反映されるように
- HTL以外のストリーミングAPIのリノート判定で投票のみを内容に含む引用リノートがピュアなリノートと誤判定される問題を修正