### PR TITLE
リモートのカスタム絵文字リアクションに便乗できるようにする

### DIFF
--- a/packages/backend/src/core/ReactionService.ts
+++ b/packages/backend/src/core/ReactionService.ts
@@ -290,7 +290,7 @@ export class ReactionService {
 
 		//#region 配信
 		if (this.userEntityService.isLocalUser(user) && !note.localOnly) {
-			const content = this.apRendererService.addContext(await this.apRendererService.renderLike(record, note, record.reaction.includes('@')));
+			const content = this.apRendererService.addContext(await this.apRendererService.renderLike(record, note, record.reaction.includes('@') && !record.reaction.endsWith('@.:')));
 			const dm = this.apDeliverManagerService.createDeliverManager(user, content);
 			if (note.userHost !== null) {
 				const reactee = await this.usersRepository.findOneBy({ id: note.userId });
@@ -347,7 +347,7 @@ export class ReactionService {
 
 		//#region 配信
 		if (this.userEntityService.isLocalUser(user) && !note.localOnly) {
-			const content = this.apRendererService.addContext(this.apRendererService.renderUndo(await this.apRendererService.renderLike(exist, note, exist.reaction.includes('@')), user));
+			const content = this.apRendererService.addContext(this.apRendererService.renderUndo(await this.apRendererService.renderLike(exist, note, exist.reaction.includes('@') && !exist.reaction.endsWith('@.:')), user));
 			const dm = this.apDeliverManagerService.createDeliverManager(user, content);
 			if (note.userHost !== null) {
 				const reactee = await this.usersRepository.findOneBy({ id: note.userId });

--- a/packages/backend/src/core/ReactionService.ts
+++ b/packages/backend/src/core/ReactionService.ts
@@ -167,7 +167,8 @@ export class ReactionService {
 				}
 
 				if (emoji) {
-					if (emoji.roleIdsThatCanBeUsedThisEmojiAsReaction.length === 0 || (await this.roleService.getUserRoles(user.id)).some(r => emoji.roleIdsThatCanBeUsedThisEmojiAsReaction.includes(r.id))) {
+					// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+					if (emoji.roleIdsThatCanBeUsedThisEmojiAsReaction.length === 0 || (await this.roleService.getUserRoles(user.id)).some(r => emoji!.roleIdsThatCanBeUsedThisEmojiAsReaction.includes(r.id))) {
 						reaction = reacterHost ? `:${name}@${reacterHost}:` : `:${name}:`;
 
 						if (localUserUsingRemoteEmoji) {

--- a/packages/backend/src/core/ReactionService.ts
+++ b/packages/backend/src/core/ReactionService.ts
@@ -130,6 +130,8 @@ export class ReactionService {
 				custom = reaction.match(isRemoteCustomEmojiRegexp);
 			}
 
+			let localUserUsingRemoteEmoji = custom ? custom.length === 3 : false;
+
 			if (custom) {
 				const reacterHost = this.utilityService.toPunyNullable(user.host);
 
@@ -141,13 +143,14 @@ export class ReactionService {
 						name,
 					});
 
-				// リモートの絵文字を指定したが同名の絵文字がローカルにある
-				if (emoji !== undefined && reacterHost == null && custom.length === 3) {
+				// ローカルユーザーがリモートの絵文字を指定したが同名の絵文字がローカルにある
+				if (emoji !== undefined && localUserUsingRemoteEmoji) {
 					custom = `:${name}:`.match(isCustomEmojiRegexp) as RegExpMatchArray;
+					localUserUsingRemoteEmoji = false;
 				}
 
 				// ローカルユーザーがリモートの絵文字を使用する
-				if (emoji === undefined && reacterHost == null && custom.length === 3) {
+				if (emoji === undefined && localUserUsingRemoteEmoji) {
 					const reactionHost = this.utilityService.toPuny(custom[2]);
 
 					// リモートの絵文字の使用は既に付いている絵文字リアクションとノート内の絵文字のみに制限しておく
@@ -167,7 +170,7 @@ export class ReactionService {
 					if (emoji.roleIdsThatCanBeUsedThisEmojiAsReaction.length === 0 || (await this.roleService.getUserRoles(user.id)).some(r => emoji.roleIdsThatCanBeUsedThisEmojiAsReaction.includes(r.id))) {
 						reaction = reacterHost ? `:${name}@${reacterHost}:` : `:${name}:`;
 
-						if (custom.length === 3) {
+						if (localUserUsingRemoteEmoji) {
 							reaction = `:${name}@${this.utilityService.toPuny(custom[2])}:`;
 						}
 

--- a/packages/frontend/src/components/MkReactionsViewer.reaction.vue
+++ b/packages/frontend/src/components/MkReactionsViewer.reaction.vue
@@ -55,7 +55,7 @@ const emojiName = computed(() => props.reaction.replace(/:/g, '').replace(/@\./,
 const emoji = computed(() => customEmojisMap.get(emojiName.value) ?? getUnicodeEmoji(props.reaction));
 
 const canToggle = computed(() => {
-	return !props.reaction.match(/@\w/) && $i && emoji.value && checkReactionPermissions($i, props.note, emoji.value);
+	return $i && emoji.value && checkReactionPermissions($i, props.note, emoji.value);
 });
 const canGetInfo = computed(() => !props.reaction.match(/@\w/) && props.reaction.includes(':'));
 

--- a/packages/frontend/src/components/global/MkCustomEmoji.vue
+++ b/packages/frontend/src/components/global/MkCustomEmoji.vue
@@ -99,10 +99,10 @@ function onClick(ev: MouseEvent) {
 			text: i18n.ts.doReaction,
 			icon: 'ti ti-plus',
 			action: () => {
-				react(`:${props.name}:`);
+				react(props.host ? `:${props.name}@${props.host}:` : `:${props.name}:`);
 				sound.playMisskeySfx('reaction');
 			},
-		}] : []), {
+		}] : []), ...(isLocal.value ? [{
 			text: i18n.ts.info,
 			icon: 'ti ti-info-circle',
 			action: async () => {
@@ -114,7 +114,7 @@ function onClick(ev: MouseEvent) {
 					anchor: ev.target,
 				});
 			},
-		}], ev.currentTarget ?? ev.target);
+		}] : [])], ev.currentTarget ?? ev.target);
 	}
 }
 </script>

--- a/packages/frontend/src/components/global/MkMisskeyFlavoredMarkdown.ts
+++ b/packages/frontend/src/components/global/MkMisskeyFlavoredMarkdown.ts
@@ -421,6 +421,8 @@ export default function (props: MfmProps, { emit }: { emit: SetupContext<MfmEven
 							normal: props.plain,
 							host: props.author.host,
 							useOriginalSize: scale >= 2.5,
+							menu: props.enableEmojiMenu,
+							menuReaction: props.enableEmojiMenuReaction,
 						})];
 					}
 				}


### PR DESCRIPTION
## What
- リモートのカスタム絵文字リアクションに便乗できるようにする
  - 使用できるリモートのカスタム絵文字は既にリアクションされているものと、ノート本文中のもののみに制限しておく
  - 指定したリモートのカスタム絵文字と同名のカスタム絵文字がローカルにある場合は、ローカルのものを指定したとみなす
 
## Additional info (optional)
- Fedibirdから便乗したリアクションが見られない気がする