### PR TITLE
ドライブのファイル登録などでproxyBypassHostsが反映されない問題を修正

### DIFF
--- a/packages/backend/src/core/DownloadService.ts
+++ b/packages/backend/src/core/DownloadService.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+import * as http from 'node:http';
+import * as https from 'node:https';
 import * as fs from 'node:fs';
 import * as stream from 'node:stream/promises';
 import { Inject, Injectable } from '@nestjs/common';
@@ -61,8 +63,8 @@ export class DownloadService {
 				request: operationTimeout,	// whole operation timeout
 			},
 			agent: {
-				http: this.httpRequestService.httpAgent,
-				https: this.httpRequestService.httpsAgent,
+				http: urlObj.protocol === 'http:' ? this.httpRequestService.getAgentByUrl(urlObj) as http.Agent : this.httpRequestService.httpAgent,
+				https: urlObj.protocol === 'https:' ? this.httpRequestService.getAgentByUrl(urlObj) as https.Agent : this.httpRequestService.httpsAgent,
 			},
 			http2: false,	// default
 			retry: {


### PR DESCRIPTION
## What
- ドライブのファイル登録などでproxyBypassHostsが反映されない問題を修正
- DownloadService.downloadUrlでHttpAgentを設定する際にHttpRequestService.getAgentByUrlの値を使用するように