### PR TITLE
ユーザープロフィールのタイムラインのデフォルトタブを「ノート」に

### DIFF
--- a/packages/frontend/src/pages/user/index.timeline.vue
+++ b/packages/frontend/src/pages/user/index.timeline.vue
@@ -28,7 +28,7 @@ const props = defineProps<{
 	user: Misskey.entities.UserDetailed;
 }>();
 
-const tab = ref<string | null>('all');
+const tab = ref<string | null>(null);
 
 const pagination = computed(() => tab.value === 'featured' ? {
 	endpoint: 'users/featured-notes' as const,


### PR DESCRIPTION
## What
- ユーザープロフィールのタイムラインのデフォルトタブを「ノート」に
