### PR TITLE
DBフォールバック時に自分宛ての返信が適切に含まれるように

### DIFF
--- a/packages/backend/src/server/api/endpoints/notes/hybrid-timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/hybrid-timeline.ts
@@ -228,6 +228,11 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 						qb // 返信だけど投稿者自身への返信
 							.where('note.replyId IS NOT NULL')
 							.andWhere('note.replyUserId = note.userId');
+					}))
+					.orWhere(new Brackets(qb => {
+						qb // 返信だけど自分宛ての返信
+							.where('note.replyId IS NOT NULL')
+							.andWhere('note.replyUserId = :meId', { meId: me.id });
 					}));
 			}));
 		}

--- a/packages/backend/src/server/api/endpoints/notes/local-timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/local-timeline.ts
@@ -190,6 +190,13 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 							.where('note.replyId IS NOT NULL')
 							.andWhere('note.replyUserId = note.userId');
 					}));
+				if (me) {
+					qb.orWhere(new Brackets(qb => {
+						qb // 返信だけど自分宛ての返信
+							.where('note.replyId IS NOT NULL')
+							.andWhere('note.replyUserId = :meId', { meId: me.id });
+					}));
+				}
 			}));
 		}
 

--- a/packages/backend/src/server/api/endpoints/notes/timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/timeline.ts
@@ -200,6 +200,11 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 					qb // 返信だけど投稿者自身への返信
 						.where('note.replyId IS NOT NULL')
 						.andWhere('note.replyUserId = note.userId');
+				}))
+				.orWhere(new Brackets(qb => {
+					qb // 返信だけど自分宛ての返信
+						.where('note.replyId IS NOT NULL')
+						.andWhere('note.replyUserId = :meId', { meId: me.id });
 				}));
 		}));
 


### PR DESCRIPTION
## What
- DBフォールバック時に、HTLで自分宛ての返信が含まれるように・LTLで（公開範囲がpublicの）自分宛ての返信が含まれるように・STLでwithRepliesの値に関係なく自分宛ての返信が含まれるように
