### PR TITLE
非ログイン時のノート数表示・ユーザータイムラインのデフォルトタブを変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "misskey",
-	"version": "2024.5.0-mame.2",
+	"version": "2024.5.0-mame.3",
 	"codename": "nasubi",
 	"repository": {
 		"type": "git",

--- a/packages/frontend/src/components/MkVisitorDashboard.vue
+++ b/packages/frontend/src/components/MkVisitorDashboard.vue
@@ -35,7 +35,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 		</div>
 		<div :class="[$style.statsItem, $style.panel]">
 			<div :class="$style.statsItemLabel">{{ i18n.ts.notes }}</div>
-			<div :class="$style.statsItemCount"><span>{{ i18n.ts.private }}</span></div>
+			<div :class="$style.statsItemCount"><span>{{ '-' }}</span></div>
 		</div>
 	</div>
 	<div v-if="instance.policies.ltlAvailable" :class="[$style.tl, $style.panel]">

--- a/packages/frontend/src/pages/about.vue
+++ b/packages/frontend/src/pages/about.vue
@@ -98,7 +98,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 							</MkKeyValue>
 							<MkKeyValue>
 								<template #key>{{ i18n.ts.notes }}</template>
-								<template #value>{{ $i ? number(stats.originalNotesCount) : i18n.ts.private }}</template>
+								<template #value>{{ $i ? number(stats.originalNotesCount) : '-' }}</template>
 							</MkKeyValue>
 						</FormSplit>
 					</FormSection>

--- a/packages/frontend/src/pages/user/home.vue
+++ b/packages/frontend/src/pages/user/home.vue
@@ -107,7 +107,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 					</div>
 					<div class="status">
 						<MkA :to="userPage(user)">
-							<b>{{ $i || user.host ? number(user.notesCount) : i18n.ts.private }}</b>
+							<b>{{ $i ? number(user.notesCount) : '-' }}</b>
 							<span>{{ i18n.ts.notes }}</span>
 						</MkA>
 						<MkA v-if="isFollowingVisibleForMe(user) && ($i || user.host == null)" :to="userPage(user, 'following')">

--- a/packages/frontend/src/pages/user/index.timeline.vue
+++ b/packages/frontend/src/pages/user/index.timeline.vue
@@ -23,12 +23,13 @@ import * as Misskey from 'misskey-js';
 import MkNotes from '@/components/MkNotes.vue';
 import MkTab from '@/components/MkTab.vue';
 import { i18n } from '@/i18n.js';
+import { $i } from '@/account.js';
 
 const props = defineProps<{
 	user: Misskey.entities.UserDetailed;
 }>();
 
-const tab = ref<string | null>(null);
+const tab = ref<string | null>($i ? null : 'all');
 
 const pagination = computed(() => tab.value === 'featured' ? {
 	endpoint: 'users/featured-notes' as const,


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
- 非ログイン時のノート数の表示を「非公開」から「-」に
- 非ログイン時のユーザータイムラインのデフォルトタブを「全て」に

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [ ] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
