### PR TITLE
非ログイン時にノート数だけを隠し、ノート数の欄はそのまま残すように

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "misskey",
-	"version": "2024.8.0-mame.1",
+	"version": "2024.8.0-mame.2",
 	"codename": "nasubi",
 	"repository": {
 		"type": "git",

--- a/packages/backend/src/server/NodeinfoServerService.ts
+++ b/packages/backend/src/server/NodeinfoServerService.ts
@@ -50,8 +50,8 @@ export class NodeinfoServerService {
 		const nodeinfo2 = async (version: number) => {
 			const now = Date.now();
 
-			const notesChart = await this.notesChart.getChart('hour', 1, null);
-			const localPosts = 0;
+			// const notesChart = await this.notesChart.getChart('hour', 1, null);
+			const localPosts = 1;
 
 			const usersChart = await this.usersChart.getChart('hour', 1, null);
 			const total = usersChart.local.total[0];

--- a/packages/backend/src/server/api/endpoints/stats.ts
+++ b/packages/backend/src/server/api/endpoints/stats.ts
@@ -71,8 +71,8 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 	) {
 		super(meta, paramDef, async (ps, me) => {
 			const notesChart = await this.notesChart.getChart('hour', 1, null);
-			const notesCount = me ? (notesChart.local.total[0] + notesChart.remote.total[0]) : 0;
-			const originalNotesCount = me ? notesChart.local.total[0] : 0;
+			const notesCount = me ? (notesChart.local.total[0] + notesChart.remote.total[0]) : 1;
+			const originalNotesCount = me ? notesChart.local.total[0] : 1;
 
 			const usersChart = await this.usersChart.getChart('hour', 1, null);
 			const usersCount = usersChart.local.total[0] + usersChart.remote.total[0];

--- a/packages/backend/test/e2e/extension.ts
+++ b/packages/backend/test/e2e/extension.ts
@@ -161,10 +161,10 @@ describe('独自拡張', () => {
 				assert.strictEqual(res.status, 405);
 			});
 
-			test('は認証がない場合レスポンスのノート数は0になる。', async () => {
+			test('は認証がない場合レスポンスのノート数は1になる。', async () => {
 				const res = await api('stats', {});
-				assert.strictEqual(res.body.notesCount, 0);
-				assert.strictEqual(res.body.originalNotesCount, 0);
+				assert.strictEqual(res.body.notesCount, 1);
+				assert.strictEqual(res.body.originalNotesCount, 1);
 			});
 
 			// チャートが即時にアップデートされないので保留
@@ -179,13 +179,13 @@ describe('独自拡張', () => {
 			{ path: '/nodeinfo/2.1' },
 			{ path: '/nodeinfo/2.0' },
 		])('$path', ({ path }) => {
-			test('のlocalPostsは0である。', async () => {
+			test('のlocalPostsは1である。', async () => {
 				const res = await relativeFetch(path, {
 					headers: {
 						Accept: 'application/json',
 					},
 				});
-				assert.strictEqual((await res.json() as any).usage.localPosts, 0);
+				assert.strictEqual((await res.json() as any).usage.localPosts, 1);
 			});
 		});
 

--- a/packages/frontend/src/components/MkUserInfo.vue
+++ b/packages/frontend/src/components/MkUserInfo.vue
@@ -19,8 +19,8 @@ SPDX-License-Identifier: AGPL-3.0-only
 		<span v-else style="opacity: 0.7;">{{ i18n.ts.noAccountDescription }}</span>
 	</div>
 	<div :class="$style.status">
-		<div v-if="$i || user.host" :class="$style.statusItem">
-			<p :class="$style.statusItemLabel">{{ i18n.ts.notes }}</p><span :class="$style.statusItemValue">{{ number(user.notesCount) }}</span>
+		<div :class="$style.statusItem">
+			<p :class="$style.statusItemLabel">{{ i18n.ts.notes }}</p><span :class="$style.statusItemValue">{{ $i ? number(user.notesCount) : '-' }}</span>
 		</div>
 		<div v-if="isFollowingVisibleForMe(user)" :class="$style.statusItem">
 			<p :class="$style.statusItemLabel">{{ i18n.ts.following }}</p><span :class="$style.statusItemValue">{{ number(user.followingCount) }}</span>

--- a/packages/frontend/src/components/MkUserPopup.vue
+++ b/packages/frontend/src/components/MkUserPopup.vue
@@ -31,9 +31,9 @@ SPDX-License-Identifier: AGPL-3.0-only
 				<div v-else style="opacity: 0.7;">{{ i18n.ts.noAccountDescription }}</div>
 			</div>
 			<div :class="$style.status">
-				<div v-if="$i || user.host" :class="$style.statusItem">
+				<div :class="$style.statusItem">
 					<div :class="$style.statusItemLabel">{{ i18n.ts.notes }}</div>
-					<div>{{ number(user.notesCount) }}</div>
+					<div>{{ $i ? number(user.notesCount) : '-' }}</div>
 				</div>
 				<div v-if="isFollowingVisibleForMe(user)" :class="$style.statusItem">
 					<div :class="$style.statusItemLabel">{{ i18n.ts.following }}</div>


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
- 非ログイン時にノート数だけを隠し、ノート数の欄はそのまま残すように
- nodeinfoやstats APIでローカルのノート数を0ではなく1とするように