### PR TITLE
iOSでIMEが有効だと絵文字ピッカーに半角空白を入力できない問題を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "misskey",
-	"version": "2024.8.0-mame.5",
+	"version": "2024.8.0-mame.6",
 	"codename": "nasubi",
 	"repository": {
 		"type": "git",

--- a/packages/frontend/src/components/MkEmojiPicker.vue
+++ b/packages/frontend/src/components/MkEmojiPicker.vue
@@ -499,7 +499,7 @@ function onKeydown(ev: KeyboardEvent) {
 }
 
 function done(query?: string): boolean | void {
-	if (query == null) query = q.value;
+	if (query == null) query = q.value.trim();
 	if (query == null || typeof query !== 'string') return;
 
 	const q2 = query.replace(/:/g, '');

--- a/packages/frontend/src/components/MkEmojiPicker.vue
+++ b/packages/frontend/src/components/MkEmojiPicker.vue
@@ -10,7 +10,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 		:value="q"
 		class="search"
 		data-prevent-emoji-insert
-		:class="{ filled: q != null && q != '' }"
+		:class="{ filled: q != null && q != '' && q.trim() != '' }"
 		:placeholder="i18n.ts.search"
 		type="search"
 		autocapitalize="off"
@@ -219,7 +219,13 @@ watch(q, () => {
 		return;
 	}
 
-	const newQ = q.value.replace(/:/g, '').toLowerCase();
+	const newQ = q.value.replace(/:/g, '').toLowerCase().trim();
+
+	if (newQ === '') {
+		searchResultCustom.value = [];
+		searchResultUnicode.value = [];
+		return;
+	}
 
 	const searchCustom = () => {
 		const max = 100;
@@ -230,7 +236,7 @@ watch(q, () => {
 		if (exactMatch) matches.add(exactMatch);
 
 		if (newQ.includes(' ')) { // AND検索
-			const keywords = newQ.split(' ');
+			const keywords = newQ.split(' ').filter(s => s !== '');
 
 			// 名前にキーワードが含まれている
 			for (const emoji of emojis) {
@@ -468,7 +474,7 @@ function input(): void {
 	// Using custom input event instead of v-model to respond immediately on
 	// Android, where composition happens on all languages
 	// (v-model does not update during composition)
-	q.value = searchEl.value?.value.trim() ?? '';
+	q.value = searchEl.value?.value ?? '';
 }
 
 function paste(event: ClipboardEvent): void {


### PR DESCRIPTION
## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
- iOSでIMEが有効だと絵文字ピッカーに半角空白を入力できず、AND検索が使えない問題を修正

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->

## Additional info (optional)
<!-- テスト観点など -->

## Checklist
- [ ] [コントリビューションガイド](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md) を確認した
- [ ] ローカル環境でテストが動作している
- [ ] （必要なら）Storybookのストーリーを追加する
- [ ] （必要なら）CHANGELOGを更新する
- [ ] （可能なら）テストを追加する
