### PR TITLE
fix strange server metrics appearance after reload

### DIFF
--- a/packages/frontend/src/widgets/server-metric/cpu-mem.vue
+++ b/packages/frontend/src/widgets/server-metric/cpu-mem.vue
@@ -138,7 +138,7 @@ function onStats(connStats: Misskey.entities.ServerStats) {
 }
 
 function onStatsLog(statsLog: Misskey.entities.ServerStatsLog) {
-	for (const revStats of statsLog.reverse()) {
+	for (const revStats of statsLog.toReversed()) {
 		onStats(revStats);
 	}
 }

--- a/packages/frontend/src/widgets/server-metric/net.vue
+++ b/packages/frontend/src/widgets/server-metric/net.vue
@@ -111,7 +111,7 @@ function onStats(connStats: Misskey.entities.ServerStats) {
 }
 
 function onStatsLog(statsLog: Misskey.entities.ServerStatsLog) {
-	for (const revStats of statsLog.reverse()) {
+	for (const revStats of statsLog.toReversed()) {
 		onStats(revStats);
 	}
 }


### PR DESCRIPTION
## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
- fix(frontend): server metrics look strange after reload (# 14467)

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->

## Additional info (optional)
<!-- テスト観点など -->

## Checklist
- [ ] [コントリビューションガイド](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md) を確認した
- [ ] ローカル環境でテストが動作している
- [ ] （必要なら）Storybookのストーリーを追加する
- [ ] （必要なら）CHANGELOGを更新する
- [ ] （可能なら）テストを追加する
