### PR TITLE
backendにあるclientのbootスクリプト等のlintルールを変更

### DIFF
--- a/packages/backend/eslint.config.js
+++ b/packages/backend/eslint.config.js
@@ -1,3 +1,4 @@
+import globals from 'globals';
 import tsParser from '@typescript-eslint/parser';
 import sharedConfig from '../shared/eslint.config.js';
 
@@ -41,6 +42,15 @@ export default [
 				name: '__filename',
 				message: 'Not in ESModule. Use `import.meta.url` instead.',
 			}],
+		},
+	},
+	{
+		files: ['src/server/web/{bios,boot,cli}.js'],
+		languageOptions: {
+			globals: {
+				...Object.fromEntries(Object.entries(globals.node).map(([key]) => [key, 'off'])),
+				...globals.browser,
+			},
 		},
 	},
 ];


### PR DESCRIPTION
## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
- packages/backend/src/server/web以下のboot.js, bios.js, cli.jsのlintルールを、ブラウザのグローバル変数を扱うように変更した

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
- 警告が多すぎて見づらい

## Additional info (optional)
<!-- テスト観点など -->

