### PR TITLE
cherry-pick: ファイルの詳細ページのファイルの説明で改行が正しく表示されない問題を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - Fix: 縦横比が極端なカスタム絵文字を表示する際にレイアウトが崩れる箇所があるのを修正  
   (Cherry-picked from https://github.com/MisskeyIO/misskey/pull/725)
 - Fix: 設定変更時のリロード確認ダイアログが複数個表示されることがある問題を修正
+- Fix: ファイルの詳細ページのファイルの説明で改行が正しく表示されない問題を修正  
+  (Cherry-picked from https://activitypub.software/TransFem-org/Sharkey/-/commit/bde6bb0bd2e8b0d027e724d2acdb8ae0585a8110)
 
 ### Server
 - ファイルがサイズの制限を超えてアップロードされた際にエラーを返さなかった問題を修正

--- a/packages/frontend/src/pages/drive.file.info.vue
+++ b/packages/frontend/src/pages/drive.file.info.vue
@@ -45,7 +45,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 				</MkKeyValue>
 			</button>
 			<button class="_button" :class="$style.kvEditBtn" @click="describe()">
-				<MkKeyValue>
+				<MkKeyValue :class="$style.multiline">
 					<template #key>{{ i18n.ts.description }}</template>
 					<template #value>{{ file.comment ? file.comment : `(${i18n.ts.none})` }}<i class="ti ti-pencil" :class="$style.kvEditIcon"></i></template>
 				</MkKeyValue>
@@ -311,6 +311,10 @@ onMounted(async () => {
 
 .fileMetaDataChildren {
 	padding: .5rem 1rem;
+}
+
+.multiline {
+	white-space: pre-wrap;
 }
 
 .kvEditBtn {


### PR DESCRIPTION
## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
- fix(frontend): ファイルの詳細ページのファイルの説明で改行が正しく表示されない問題を修正 (# 14588)

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->


## Additional info (optional)
<!-- テスト観点など -->

