### PR TITLE
クリップ追加のエラー処理を適切に行う

### DIFF
--- a/packages/backend/src/core/ClipService.ts
+++ b/packages/backend/src/core/ClipService.ts
@@ -116,7 +116,7 @@ export class ClipService {
 			if (e instanceof QueryFailedError) {
 				if (isDuplicateKeyValueError(e)) {
 					throw new ClipService.AlreadyAddedError();
-				} else if (e.driverError.detail.includes('is not present in table "note".')) {
+				} else if (e.driverError.constraint === 'FK_a012eaf5c87c65da1deb5fdbfa3') {
 					throw new ClipService.NoSuchNoteError();
 				}
 			}

--- a/packages/backend/src/core/ClipService.ts
+++ b/packages/backend/src/core/ClipService.ts
@@ -116,7 +116,7 @@ export class ClipService {
 			if (e instanceof QueryFailedError) {
 				if (isDuplicateKeyValueError(e)) {
 					throw new ClipService.AlreadyAddedError();
-				} else if (e.driverError.constraint === 'FK_a012eaf5c87c65da1deb5fdbfa3') {
+				} else if (e.driverError.code === '23503' && e.driverError.constraint === 'FK_a012eaf5c87c65da1deb5fdbfa3') {
 					throw new ClipService.NoSuchNoteError();
 				}
 			}


### PR DESCRIPTION
## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
- クリップに存在しないノートを追加しようとしたときのエラー処理を適切に
  - エラーメッセージの一部を用いてノートが存在しないことを確認しようとしていたため、日本語環境では条件に引っかからずに内部エラーが出てきていた
  - 外部キー違反のエラーコードと外部キー制約のIDを用いて処理するように

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->


## Additional info (optional)
<!-- テスト観点など -->

