### PR TITLE
backendのソースを不完全な状態で保存してもpnpm devが適切に動き続けるように

### DIFF
--- a/packages/backend/eslint.config.js
+++ b/packages/backend/eslint.config.js
@@ -53,4 +53,10 @@ export default [
 			},
 		},
 	},
+	{
+		files: ['scripts/*.mjs'],
+		languageOptions: {
+			globals: globals.node,
+		},
+	},
 ];


### PR DESCRIPTION
## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
- backendの./built/boot/entry.jsの実行が失敗しても、pnpm devが適切に動き続けるように

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->


## Additional info (optional)
<!-- テスト観点など -->

