### PR TITLE
cherry-pick: fix wrong hashtag channel param type

### DIFF
--- a/packages/misskey-js/etc/misskey-js.api.md
+++ b/packages/misskey-js/etc/misskey-js.api.md
@@ -572,7 +572,7 @@ export type Channels = {
     };
     hashtag: {
         params: {
-            q?: string;
+            q: string[][];
         };
         events: {
             note: (payload: Note) => void;

--- a/packages/misskey-js/src/streaming.types.ts
+++ b/packages/misskey-js/src/streaming.types.ts
@@ -88,7 +88,7 @@ export type Channels = {
 	};
 	hashtag: {
 		params: {
-			q?: string;
+			q: string[][];
 		};
 		events: {
 			note: (payload: Note) => void;


### PR DESCRIPTION
## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
- fix(misskey-js): wrong hashtag channel param type (# 14611)

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->


## Additional info (optional)
<!-- テスト観点など -->

