### PR TITLE
cherry-pick: `<link rel="alternate">`を追って照会するのはOKレスポンスが返却された場合のみに

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@
   (Cherry-picked from https://activitypub.software/TransFem-org/Sharkey/-/commit/8a982c61c01909e7540ff1be9f019df07c3f0624)
 - Fix: サーバーサイドのDOM解析完了時にリソースを開放するように
 	(Cherry-picked from https://activitypub.software/TransFem-org/Sharkey/-/merge_requests/634)
+- Fix: `<link rel="alternate">`を追って照会するのはOKレスポンスが返却された場合のみに  
+  (Cherry-picked from https://activitypub.software/TransFem-org/Sharkey/-/merge_requests/633)
 
 ## 2024.8.0
 

--- a/packages/backend/src/core/activitypub/ApRequestService.ts
+++ b/packages/backend/src/core/activitypub/ApRequestService.ts
@@ -205,7 +205,11 @@ export class ApRequestService {
 		//#region リクエスト先がhtmlかつactivity+jsonへのalternate linkタグがあるとき
 		const contentType = res.headers.get('content-type');
 
-		if ((contentType ?? '').split(';')[0].trimEnd().toLowerCase() === 'text/html' && _followAlternate === true) {
+		if (
+			res.ok &&
+			(contentType ?? '').split(';')[0].trimEnd().toLowerCase() === 'text/html' &&
+			_followAlternate === true
+		) {
 			const html = await res.text();
 			const { window, happyDOM } = new Window({
 				settings: {


### PR DESCRIPTION
## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
- Fix: `<link rel="alternate">`を追って照会するのはOKレスポンスが返却された場合のみに (# 14627)

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->


## Additional info (optional)
<!-- テスト観点など -->

