### PR TITLE
タグ欄を1行に設定しているときに日本語のタグがあるとテキストが1文字ごとに折り返されているのを修正

### DIFF
--- a/packages/frontend/src/components/MkEmojiPicker.vue
+++ b/packages/frontend/src/components/MkEmojiPicker.vue
@@ -749,6 +749,7 @@ defineExpose({
 				padding-block: 0.2rem;
 				margin-inline: 4px;
 				margin-block: 4px;
+				white-space: nowrap;
 
 				&:hover {
 					cursor: pointer;


### PR DESCRIPTION
## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->


## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->


## Additional info (optional)
<!-- テスト観点など -->

