### PR TITLE
disableClusteringを有効にしているとNestインスタンスが無駄に複数立ち上がるのを修正

### DIFF
--- a/packages/backend/src/boot/entry.ts
+++ b/packages/backend/src/boot/entry.ts
@@ -77,7 +77,7 @@ if (cluster.isPrimary || envOption.disableClustering) {
 	}
 }
 
-if (cluster.isWorker || envOption.disableClustering) {
+if (cluster.isWorker) {
 	await workerMain();
 }
 


### PR DESCRIPTION
## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
- disableClustering有効時もworkerMainを呼び出すため、ジョブキューが2つ呼ばれる
- disableClustering有効かつonlyServer有効だと、workerMain内でサーバーを立ち上げようとするため、masterMainの方のサーバーとポートが被って落ちる

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->


## Additional info (optional)
<!-- テスト観点など -->

