### PR TITLE
ci: リリースの作成にGitHub Appのトークンを使用するように

### DIFF
--- a/.github/workflows/release-on-push.yml
+++ b/.github/workflows/release-on-push.yml
@@ -74,23 +74,35 @@ jobs:
         run: git rev-parse HEAD > ./built/hash
       - name: Archive (tar)
         run: tar -zcvf ./built.tar.gz ./built ./packages/misskey-js/built ./packages/backend/built
+      - name: Get repository name
+        id: repository-name
+        run: echo "name=${GITHUB_REPOSITORY#${GITHUB_REPOSITORY_OWNER}/}" >> $GITHUB_OUTPUT
+      - name: Get GitHub App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            ${{ steps.repository-name.outputs.name }}
       - name: Remove existing release and tag
         if: ${{ steps.version_changed.outputs.version_changed == 'false' }}
         run: |
           if gh release delete "$TAG_NAME" -y --cleanup-tag; then : ; else : ; fi
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG_NAME: ${{ steps.tag_name.outputs.tag_name }}
       - name: Remove existing release and tag
         if: ${{ steps.version_changed.outputs.version_changed == 'true' }}
         run: |
           if gh release delete "$PREV_RELEASE" -y --cleanup-tag; then : ; else : ; fi
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PREV_RELEASE: ${{ steps.previous_version.outputs.previous_version }}.next
       - name: Create release
         run: gh release create "$TAG_NAME" ./built.tar.gz --latest --generate-notes --notes-start-tag "$NOTES_START_TAG"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG_NAME: ${{ steps.tag_name.outputs.tag_name }}
           NOTES_START_TAG: ${{ steps.notes_start_tag.outputs.notes_start_tag }}


### PR DESCRIPTION
## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
- リリースの作成にGitHub Appのトークンを使用するように

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
- `on: release`のWorkflowが起動しなくて不便

## Additional info (optional)
<!-- テスト観点など -->

