### PR TITLE
allowPartialを削除

### DIFF
--- a/packages/backend/src/core/FanoutTimelineEndpointService.ts
+++ b/packages/backend/src/core/FanoutTimelineEndpointService.ts
@@ -22,7 +22,6 @@ type TimelineOptions = {
 	untilId: string | null,
 	sinceId: string | null,
 	limit: number,
-	allowPartial: boolean,
 	me?: { id: MiUser['id'] } | undefined | null,
 	useDbFallback: boolean,
 	redisTimelines: FanoutTimelineName[],
@@ -139,7 +138,7 @@ export class FanoutTimelineEndpointService {
 				redisTimeline.push(...gotFromDb);
 				lastSuccessfulRate = gotFromDb.length / noteIds.length;
 
-				if (ps.allowPartial ? redisTimeline.length !== 0 : redisTimeline.length >= ps.limit) {
+				if (redisTimeline.length >= ps.limit) {
 					// 十分Redisからとれた
 					return redisTimeline.slice(0, ps.limit);
 				}

--- a/packages/backend/src/server/api/endpoints/channels/timeline.ts
+++ b/packages/backend/src/server/api/endpoints/channels/timeline.ts
@@ -47,7 +47,6 @@ export const paramDef = {
 		untilId: { type: 'string', format: 'misskey:id' },
 		sinceDate: { type: 'integer' },
 		untilDate: { type: 'integer' },
-		allowPartial: { type: 'boolean', default: false }, // true is recommended but for compatibility false by default
 	},
 	required: ['channelId'],
 } as const;
@@ -89,7 +88,6 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 				untilId,
 				sinceId,
 				limit: ps.limit,
-				allowPartial: ps.allowPartial,
 				me,
 				useDbFallback: true,
 				redisTimelines: [`channelTimeline:${channel.id}`],

--- a/packages/backend/src/server/api/endpoints/notes/hybrid-timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/hybrid-timeline.ts
@@ -58,7 +58,6 @@ export const paramDef = {
 		untilId: { type: 'string', format: 'misskey:id' },
 		sinceDate: { type: 'integer' },
 		untilDate: { type: 'integer' },
-		allowPartial: { type: 'boolean', default: false }, // true is recommended but for compatibility false by default
 		includeMyRenotes: { type: 'boolean', default: true },
 		includeRenotedMyNotes: { type: 'boolean', default: true },
 		includeLocalRenotes: { type: 'boolean', default: true },
@@ -147,7 +146,6 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 				untilId,
 				sinceId,
 				limit: ps.limit,
-				allowPartial: ps.allowPartial,
 				me,
 				redisTimelines: timelineConfig,
 				useDbFallback: this.serverSettings.enableFanoutTimelineDbFallback,

--- a/packages/backend/src/server/api/endpoints/notes/local-timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/local-timeline.ts
@@ -53,7 +53,6 @@ export const paramDef = {
 		limit: { type: 'integer', minimum: 1, maximum: 100, default: 10 },
 		sinceId: { type: 'string', format: 'misskey:id' },
 		untilId: { type: 'string', format: 'misskey:id' },
-		allowPartial: { type: 'boolean', default: false }, // true is recommended but for compatibility false by default
 		sinceDate: { type: 'integer' },
 		untilDate: { type: 'integer' },
 	},
@@ -103,7 +102,6 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 				untilId,
 				sinceId,
 				limit: ps.limit,
-				allowPartial: ps.allowPartial,
 				me,
 				useDbFallback: this.serverSettings.enableFanoutTimelineDbFallback,
 				redisTimelines:

--- a/packages/backend/src/server/api/endpoints/notes/timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/timeline.ts
@@ -41,7 +41,6 @@ export const paramDef = {
 		untilId: { type: 'string', format: 'misskey:id' },
 		sinceDate: { type: 'integer' },
 		untilDate: { type: 'integer' },
-		allowPartial: { type: 'boolean', default: false }, // true is recommended but for compatibility false by default
 		includeMyRenotes: { type: 'boolean', default: true },
 		includeRenotedMyNotes: { type: 'boolean', default: true },
 		includeLocalRenotes: { type: 'boolean', default: true },
@@ -99,7 +98,6 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 				untilId,
 				sinceId,
 				limit: ps.limit,
-				allowPartial: ps.allowPartial,
 				me,
 				useDbFallback: this.serverSettings.enableFanoutTimelineDbFallback,
 				redisTimelines: ps.withFiles ? [`homeTimelineWithFiles:${me.id}`] : [`homeTimeline:${me.id}`],

--- a/packages/backend/src/server/api/endpoints/notes/user-list-timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/user-list-timeline.ts
@@ -50,7 +50,6 @@ export const paramDef = {
 		untilId: { type: 'string', format: 'misskey:id' },
 		sinceDate: { type: 'integer' },
 		untilDate: { type: 'integer' },
-		allowPartial: { type: 'boolean', default: false }, // true is recommended but for compatibility false by default
 		includeMyRenotes: { type: 'boolean', default: true },
 		includeRenotedMyNotes: { type: 'boolean', default: true },
 		includeLocalRenotes: { type: 'boolean', default: true },
@@ -119,7 +118,6 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 				untilId,
 				sinceId,
 				limit: ps.limit,
-				allowPartial: ps.allowPartial,
 				me,
 				useDbFallback: this.serverSettings.enableFanoutTimelineDbFallback,
 				redisTimelines: ps.withFiles ? [`userListTimelineWithFiles:${list.id}`] : [`userListTimeline:${list.id}`],

--- a/packages/backend/src/server/api/endpoints/users/notes.ts
+++ b/packages/backend/src/server/api/endpoints/users/notes.ts
@@ -57,7 +57,6 @@ export const paramDef = {
 		untilId: { type: 'string', format: 'misskey:id' },
 		sinceDate: { type: 'integer' },
 		untilDate: { type: 'integer' },
-		allowPartial: { type: 'boolean', default: false }, // true is recommended but for compatibility false by default
 		withFiles: { type: 'boolean', default: false },
 	},
 	required: ['userId'],
@@ -118,7 +117,6 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 				untilId,
 				sinceId,
 				limit: ps.limit,
-				allowPartial: ps.allowPartial,
 				me,
 				redisTimelines,
 				useDbFallback: true,

--- a/packages/frontend/src/components/MkPagination.vue
+++ b/packages/frontend/src/components/MkPagination.vue
@@ -207,7 +207,6 @@ async function init(): Promise<void> {
 	await misskeyApi<Entity[]>(props.pagination.endpoint, {
 		...params,
 		limit: props.pagination.limit ?? 10,
-		allowPartial: true,
 	}).then(res => {
 		if (res.length === 0 || props.pagination.noPaging) {
 			concatItems(res);

--- a/packages/misskey-js/src/autogen/types.ts
+++ b/packages/misskey-js/src/autogen/types.ts
@@ -9222,8 +9222,6 @@ export type operations = {
           untilId?: string;
           sinceDate?: number;
           untilDate?: number;
-          /** @default false */
-          allowPartial?: boolean;
         };
       };
     };
@@ -17414,8 +17412,6 @@ export type operations = {
           untilId?: string;
           sinceDate?: number;
           untilDate?: number;
-          /** @default false */
-          allowPartial?: boolean;
           /** @default true */
           includeMyRenotes?: boolean;
           /** @default true */
@@ -17492,8 +17488,6 @@ export type operations = {
           sinceId?: string;
           /** Format: misskey:id */
           untilId?: string;
-          /** @default false */
-          allowPartial?: boolean;
           sinceDate?: number;
           untilDate?: number;
         };
@@ -18327,8 +18321,6 @@ export type operations = {
           untilId?: string;
           sinceDate?: number;
           untilDate?: number;
-          /** @default false */
-          allowPartial?: boolean;
           /** @default true */
           includeMyRenotes?: boolean;
           /** @default true */
@@ -18521,8 +18513,6 @@ export type operations = {
           untilId?: string;
           sinceDate?: number;
           untilDate?: number;
-          /** @default false */
-          allowPartial?: boolean;
           /** @default true */
           includeMyRenotes?: boolean;
           /** @default true */
@@ -20816,8 +20806,6 @@ export type operations = {
           untilId?: string;
           sinceDate?: number;
           untilDate?: number;
-          /** @default false */
-          allowPartial?: boolean;
           /** @default false */
           withFiles?: boolean;
         };


### PR DESCRIPTION
## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
- allowPartialを削除

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
- MkPaginationの最初の描画で`limit: 10`と共に`allowPartial: true`が使われているが、10個未満ノートを返されても表示領域を埋めきれず、すぐに2回目のリクエストが走ることが多く意味ない
- 2回リクエストが走るとちらつきのように見えてユーザー体験を損なう

## Additional info (optional)
<!-- テスト観点など -->

