### PR TITLE
バージョニング方法を変更

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,17 +2,17 @@ name: Publish Docker image
 
 on:
   release:
-    types: [released]
+    types: [released, prereleased]
   workflow_dispatch:
 
 env:
   REGISTRY_IMAGE: adzukimame/misskey
   TAGS: |
-    type=edge
-    type=semver,pattern={{version}}
-    type=semver,pattern={{major}}.{{minor}},enable=${{ !endsWith(github.event.release.name, '.next') }}
-    type=semver,pattern={{major}},enable=${{ !endsWith(github.event.release.name, '.next') }}
-    type=raw,value=latest,enable=${{ !endsWith(github.event.release.name, '.next') }}
+    type=raw,value=edge
+    type=semver,pattern={{major}}.{{minor}}.{{patch}},enable=${{ github.event.release.name != 'edge' && !contains(github.event.release.name, '-') }}
+    type=semver,pattern={{major}}.{{minor}},enable=${{ github.event.release.name != 'edge' && !contains(github.event.release.name, '-') }}
+    type=semver,pattern={{major}},enable=${{ github.event.release.name != 'edge' && !contains(github.event.release.name, '-') }}
+    type=raw,value=latest,enable=${{ github.event.release.name != 'edge' && !contains(github.event.release.name, '-') }}
 
 jobs:
   # see https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners

--- a/.github/workflows/release-on-push.yml
+++ b/.github/workflows/release-on-push.yml
@@ -20,16 +20,21 @@ jobs:
         with:
           fetch-tags: true
           fetch-depth: 2
+
       - name: Save current version
         id: current_version
-        run: echo "current_version=$(jq -r '.version' ./package.json)" >> $GITHUB_OUTPUT
+        run: echo "current_version=$(jq -r '.version | split("+")[0]' ./package.json)" >> $GITHUB_OUTPUT
+
       - name: Checkout previous commit
         run: git checkout HEAD^
+
       - name: Save version on previous commit
         id: previous_version
-        run: echo "previous_version=$(jq -r '.version' ./package.json)" >> $GITHUB_OUTPUT
+        run: echo "previous_version=$(jq -r '.version | split("+")[0]' ./package.json)" >> $GITHUB_OUTPUT
+
       - name: Checkout main branch
         run: git checkout $(git name-rev --name-only $(git reflog -n 1 --skip=1 --pretty='%H'))
+
       - name: Check if version changed
         id: version_changed
         run: |
@@ -38,47 +43,43 @@ jobs:
         env:
           PREV_VER: ${{ steps.previous_version.outputs.previous_version }}
           CURR_VER: ${{ steps.current_version.outputs.current_version }}
-      - name: Determine new tag name
-        id: tag_name
-        run: |
-          SUFFIX=$(if [ '${{ steps.version_changed.outputs.version_changed }}' == 'true' ]; then echo ''; else echo '.next'; fi)
-          echo "tag_name=$CURR_VER$SUFFIX" >> $GITHUB_OUTPUT
-        env:
-          CURR_VER: ${{ steps.current_version.outputs.current_version }}
-      - name: Determine starting point of release note generation
-        id: notes_start_tag
-        run: |
-          START_TAG=$(if [ '${{ steps.version_changed.outputs.version_changed }}' == 'true' ]; then echo "$PREV_VER"; else echo "$CURR_VER"; fi)
-          echo "notes_start_tag=$START_TAG" >> $GITHUB_OUTPUT
-        env:
-          PREV_VER: ${{ steps.previous_version.outputs.previous_version }}
-          CURR_VER: ${{ steps.current_version.outputs.current_version }}
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
+
       - name: Setup Node.js
         uses: actions/setup-node@v4.0.3
         with:
           node-version-file: '.node-version'
           cache: 'pnpm'
+
       - name: Install Corepack
         run: npm install -g corepack@latest
+
       - name: Enable Corepack
         run: corepack enable
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
       - name: Check if lock file is not modified
         run: git diff --exit-code pnpm-lock.yaml
+
       - name: Build
         run: pnpm run build
         env:
           NODE_ENV: production
+
       - name: Note latest commit hash
         run: git rev-parse HEAD > ./built/hash
+
       - name: Archive (tar)
         run: tar -zcvf ./built.tar.gz ./built ./packages/misskey-js/built ./packages/backend/built
+
       - name: Get repository name
         id: repository-name
         run: echo "name=${GITHUB_REPOSITORY#${GITHUB_REPOSITORY_OWNER}/}" >> $GITHUB_OUTPUT
+
       - name: Get GitHub App Token
         uses: actions/create-github-app-token@v1
         id: app-token
@@ -88,23 +89,28 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: |
             ${{ steps.repository-name.outputs.name }}
-      - name: Remove existing release and tag
+
+      # on version not changed
+      - name: Remove existing edge release and tag
         if: ${{ steps.version_changed.outputs.version_changed == 'false' }}
         run: |
-          if gh release delete "$TAG_NAME" -y --cleanup-tag; then : ; else : ; fi
+          gh release delete "edge" -y --cleanup-tag || true
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          TAG_NAME: ${{ steps.tag_name.outputs.tag_name }}
-      - name: Remove existing release and tag
+
+      # on version not changed
+      - name: Create edge release
+        if: ${{ steps.version_changed.outputs.version_changed == 'false' }}
+        run: gh release create "edge" ./built.tar.gz --prerelease --generate-notes --notes-start-tag "$NOTES_START_TAG"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          NOTES_START_TAG: ${{ steps.current_version.outputs.current_version }}
+
+      # on version changed
+      - name: Create versioned release
         if: ${{ steps.version_changed.outputs.version_changed == 'true' }}
-        run: |
-          if gh release delete "$PREV_RELEASE" -y --cleanup-tag; then : ; else : ; fi
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          PREV_RELEASE: ${{ steps.previous_version.outputs.previous_version }}.next
-      - name: Create release
         run: gh release create "$TAG_NAME" ./built.tar.gz --latest --generate-notes --notes-start-tag "$NOTES_START_TAG"
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          TAG_NAME: ${{ steps.tag_name.outputs.tag_name }}
-          NOTES_START_TAG: ${{ steps.notes_start_tag.outputs.notes_start_tag }}
+          TAG_NAME: ${{ steps.current_version.outputs.current_version }}
+          NOTES_START_TAG: ${{ steps.previous_version.outputs.previous_version }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "misskey",
-	"version": "2024.10.1-mame.10",
+	"version": "2024.10.1010+upstream.2024.10.1",
 	"codename": "nasubi",
 	"repository": {
 		"type": "git",

--- a/packages/misskey-js/package.json
+++ b/packages/misskey-js/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "misskey-js",
-	"version": "2024.10.1-mame.10",
+	"version": "2024.10.1010+upstream.2024.10.1",
 	"description": "Misskey SDK for JavaScript",
 	"license": "MIT",
 	"main": "./built/index.js",


### PR DESCRIPTION
## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
- バージョニング方法を変更
- semverのprerelease部分に-mameをつけるのをやめる
- パッチバージョンを1000番台にする
- +以降にupstreamのバージョンを記す
- 1つ前のコミットと比較してpackage.jsonの
  - バージョンが変わっていれば
    - 新しいバージョン名でReleaseを作成
    - edge Releaseを削除
    - Dockerにはsemver (3種), latest, edgeのタグをプッシュ
  - バージョンが変わっていなければ
    - edge Releaseを作成／更新
    - Dockerにはedgeのタグをプッシュ

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->


## Additional info (optional)
<!-- テスト観点など -->
- Dockerではedgeは常に最新のコードベースを反映する
- GitHub Releasesではedgeが出現したり消えたりする
  - なんとかしたい
- バージョン名に-betaとかを付けたとき
  - Dockerは更新されない
  - GitHub Releasesはlatestとしてリリースされる
    - なんとかしたい