### PR TITLE
Cloudflare Challengesの期限切れでAPIコールが失敗した場合にTurnstileのウィジェットを表示する

### DIFF
--- a/locales/en-US.yml
+++ b/locales/en-US.yml
@@ -2722,3 +2722,8 @@ _embedCodeGen:
   generateCode: "Generate embed code"
   codeGenerated: "The code has been generated"
   codeGeneratedDescription: "Paste the generated code into your website to embed the content."
+
+_cloudflareChallenges:
+  verificationRequired: "Security Verification"
+  verificationDescription: "Please complete the security verification to continue."
+  verificationCompleted: "Security verification completed. Please try again."

--- a/locales/index.d.ts
+++ b/locales/index.d.ts
@@ -10433,6 +10433,20 @@ export interface Locale extends ILocale {
          */
         "native": string;
     };
+    "_cloudflareChallenges": {
+        /**
+         * セキュリティチェック
+         */
+        "verificationRequired": string;
+        /**
+         * 続行するにはセキュリティチェックを完了してください。
+         */
+        "verificationDescription": string;
+        /**
+         * セキュリティチェックが完了しました。もう一度お試しください。
+         */
+        "verificationCompleted": string;
+    };
 }
 declare const locales: {
     [lang: string]: Locale;

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -2778,3 +2778,8 @@ _contextMenu:
   app: "アプリケーション"
   appWithShift: "Shiftキーでアプリケーション"
   native: "ブラウザのUI"
+
+_cloudflareChallenges:
+  verificationRequired: "セキュリティチェック"
+  verificationDescription: "続行するにはセキュリティチェックを完了してください。"
+  verificationCompleted: "セキュリティチェックが完了しました。もう一度お試しください。"

--- a/packages/frontend/src/components/MkCloudflareChallengeDialog.vue
+++ b/packages/frontend/src/components/MkCloudflareChallengeDialog.vue
@@ -1,0 +1,147 @@
+<!--
+SPDX-FileCopyrightText: adzuki
+SPDX-License-Identifier: AGPL-3.0-only
+-->
+
+<template>
+<MkModal ref="modal" :preferType="'dialog'" :zPriority="'high'" @closed="emit('closed')">
+	<div :class="[$style.root, { [$style.completed]: completed }]">
+		<!-- Show Turnstile widget while not completed -->
+		<div v-if="!completed">
+			<div :class="$style.icon">
+				<i class="ti ti-shield-check"></i>
+			</div>
+			<header :class="$style.title">{{ i18n.ts._cloudflareChallenges.verificationRequired }}</header>
+			<div :class="$style.text">{{ i18n.ts._cloudflareChallenges.verificationDescription }}</div>
+
+			<MkCaptcha
+				ref="captchaEl"
+				v-model="turnstileResponse"
+				provider="turnstile"
+				:sitekey="sitekey"
+			/>
+
+			<MkButton :class="$style.cancelButton" @click="cancel">
+				{{ i18n.ts.cancel }}
+			</MkButton>
+		</div>
+
+		<!-- Show success message after completion -->
+		<div v-else :class="$style.successContainer">
+			<i :class="[$style.icon, $style.successIcon]" class="ti ti-check"></i>
+			<div :class="$style.successText">{{ i18n.ts._cloudflareChallenges.verificationCompleted }}</div>
+			<MkButton primary :class="$style.closeButton" @click="close">
+				{{ i18n.ts.close }}
+			</MkButton>
+		</div>
+	</div>
+</MkModal>
+</template>
+
+<script lang="ts" setup>
+import { ref, shallowRef, watch } from 'vue';
+import MkModal from '@/components/MkModal.vue';
+import MkCaptcha from '@/components/MkCaptcha.vue';
+import MkButton from '@/components/MkButton.vue';
+import { i18n } from '@/i18n.js';
+
+const props = defineProps<{
+	sitekey: string;
+}>();
+
+const emit = defineEmits<{
+	(ev: 'completed'): void;
+	(ev: 'cancelled'): void;
+	(ev: 'closed'): void;
+}>();
+
+const modal = shallowRef<InstanceType<typeof MkModal>>();
+const captchaEl = shallowRef<InstanceType<typeof MkCaptcha>>();
+const turnstileResponse = ref<string | null>(null);
+const completed = ref(false);
+
+function cancel() {
+	emit('cancelled');
+	if (modal.value) modal.value.close();
+}
+
+function close() {
+	if (modal.value) modal.value.close();
+}
+
+// Watch for challenge completion
+watch(turnstileResponse, (newValue) => {
+	if (newValue && !completed.value) {
+		// User completed the challenge
+		completed.value = true;
+		emit('completed');
+
+		// Auto-close after 3 seconds
+		setTimeout(() => {
+			if (modal.value) modal.value.close();
+		}, 4000);
+	}
+});
+</script>
+
+<style lang="scss" module>
+.root {
+	margin: auto;
+	position: relative;
+	padding: 32px;
+	box-sizing: border-box;
+	text-align: center;
+	background: var(--MI_THEME-panel);
+	border-radius: var(--MI-radius);
+	min-width: 320px;
+	max-width: 480px;
+
+	&.completed {
+		padding: 48px 32px;
+	}
+}
+
+.icon {
+	font-size: 48px;
+	margin-bottom: 16px;
+	color: var(--MI_THEME-accent);
+
+	&.successIcon {
+		font-size: 64px;
+		color: var(--MI_THEME-success);
+	}
+}
+
+.title {
+	font-size: 1.2em;
+	font-weight: bold;
+	margin-bottom: 8px;
+}
+
+.text {
+	margin-bottom: 16px;
+	color: var(--MI_THEME-fg);
+	opacity: 0.8;
+}
+
+.cancelButton {
+	margin-top: 16px;
+}
+
+.successContainer {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 16px;
+}
+
+.successText {
+	font-size: 1.1em;
+	line-height: 1.5;
+	color: var(--MI_THEME-fg);
+}
+
+.closeButton {
+	margin-top: 8px;
+}
+</style>

--- a/packages/frontend/src/scripts/cloudflare-challenge.ts
+++ b/packages/frontend/src/scripts/cloudflare-challenge.ts
@@ -1,0 +1,52 @@
+/*
+ * SPDX-FileCopyrightText: adzuki
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { popup } from '@/os.js';
+import MkCloudflareChallengeDialog from '@/components/MkCloudflareChallengeDialog.vue';
+import { instance } from '@/instance.js';
+
+/**
+ * Show Cloudflare challenge dialog
+ * @returns Promise that resolves when challenge completes, rejects if cancelled or not configured
+ */
+export async function showCloudflareChallengeDialog(): Promise<void> {
+	// Check if Turnstile is configured
+	if (!instance.turnstileSiteKey) {
+		// Not configured - don't show dialog
+		return Promise.reject(new Error('Turnstile not configured'));
+	}
+
+	return new Promise<void>((resolve, reject) => {
+		let resolved = false;
+
+		const { dispose } = popup(MkCloudflareChallengeDialog, {
+			sitekey: instance.turnstileSiteKey!,
+		}, {
+			completed: () => {
+				// Challenge completed, Cloudflare cookie is now set
+				// User can retry the operation manually
+				if (!resolved) {
+					resolved = true;
+					resolve();
+				}
+			},
+			cancelled: () => {
+				// User cancelled
+				if (!resolved) {
+					resolved = true;
+					reject(new Error('Challenge cancelled by user'));
+				}
+			},
+			closed: () => {
+				// Dialog closed - ensure promise is resolved/rejected
+				if (!resolved) {
+					resolved = true;
+					reject(new Error('Dialog closed without completion'));
+				}
+				dispose();
+			},
+		});
+	});
+}

--- a/packages/frontend/src/scripts/misskey-api.ts
+++ b/packages/frontend/src/scripts/misskey-api.ts
@@ -46,6 +46,39 @@ export function misskeyApi<
 			},
 			signal,
 		}).then(async (res) => {
+			//#region Blocked by Cloudflare WAF
+			if (res.headers.get('cf-mitigated') === 'challenge') {
+				// Import handler dynamically to avoid circular dependency
+				const { showCloudflareChallengeDialog } = await import('@/scripts/cloudflare-challenge.js');
+
+				try {
+					// Show challenge dialog (will resolve when challenge completes)
+					await showCloudflareChallengeDialog();
+
+					// Challenge completed successfully
+					// Reject with specific error so user knows to retry
+					reject({
+						code: 'CLOUDFLARE_CHALLENGE_REQUIRED',
+						message: 'Please try again',
+						id: '3f5336d7-2706-494b-811e-fe98d0e65a5d',
+					});
+				} catch (err) {
+					// Challenge dialog not shown (not configured) or user cancelled
+					// Pass through the original error/response
+					const body = res.status === 204 ? null : await res.json();
+					if (res.status === 200) {
+						resolve(body);
+					} else if (res.status === 204) {
+						resolve(undefined as _ResT);
+					} else {
+						reject(body.error);
+					}
+				}
+				return; // Don't continue with normal processing
+			}
+			//#endregion
+
+			// Normal response handling
 			const body = res.status === 204 ? null : await res.json();
 
 			if (res.status === 200) {
@@ -89,6 +122,39 @@ export function misskeyApiGet<
 			mode: 'same-origin',
 			cache: 'default',
 		}).then(async (res) => {
+			//#region Blocked by Cloudflare WAF
+			if (res.headers.get('cf-mitigated') === 'challenge') {
+				// Import handler dynamically to avoid circular dependency
+				const { showCloudflareChallengeDialog } = await import('@/scripts/cloudflare-challenge.js');
+
+				try {
+					// Show challenge dialog (will resolve when challenge completes)
+					await showCloudflareChallengeDialog();
+
+					// Challenge completed successfully
+					// Reject with specific error so user knows to retry
+					reject({
+						code: 'CLOUDFLARE_CHALLENGE_REQUIRED',
+						message: 'Please try again',
+						id: 'c0a62bcd-472b-43c9-8b5e-94de043f1eeb',
+					});
+				} catch (err) {
+					// Challenge dialog not shown (not configured) or user cancelled
+					// Pass through the original error/response
+					const body = res.status === 204 ? null : await res.json();
+					if (res.status === 200) {
+						resolve(body);
+					} else if (res.status === 204) {
+						resolve(undefined as _ResT);
+					} else {
+						reject(body.error);
+					}
+				}
+				return; // Don't continue with normal processing
+			}
+			//#endregion
+
+			// Normal response handling
 			const body = res.status === 204 ? null : await res.json();
 
 			if (res.status === 200) {


### PR DESCRIPTION
Cloudflare Challengesの期限切れでAPIコールが失敗した場合にTurnstileのウィジェットを表示してpre-clearanceを行うように

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->


## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
- タブごとリロードしなくて済む

## Additional info (optional)
<!-- テスト観点など -->

