### PR TITLE
turnstile, pre-clearance関連のコンポーネントをメインチャンクに追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "misskey",
-	"version": "2024.10.1014+upstream.2024.10.1",
+	"version": "2024.10.1015+upstream.2024.10.1",
 	"codename": "nasubi",
 	"repository": {
 		"type": "git",

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -136,9 +136,26 @@ export function getConfig(): UserConfig {
 				},
 				external: externalPackages.map(p => p.match),
 				output: {
-					manualChunks: {
-						vue: ['vue'],
-						photoswipe: ['photoswipe', 'photoswipe/lightbox', 'photoswipe/style.css'],
+					manualChunks(id) {
+						// Critical components that must be available before any Cloudflare challenge
+						// These must be in the main bundle because dynamic import chunks can be blocked by WAF
+						if (id.includes('/src/scripts/cloudflare-challenge.ts') ||
+						    id.includes('/src/components/MkCloudflareChallengeDialog.vue') ||
+						    id.includes('/src/components/MkCaptcha.vue') ||
+						    id.includes('/src/components/MkModal.vue')) {
+							return 'app';
+						}
+
+						// Standard chunking - check for node_modules paths
+						if (id.includes('node_modules/vue/')) {
+							return 'vue';
+						}
+						if (id.includes('node_modules/photoswipe/')) {
+							return 'photoswipe';
+						}
+
+						// Let Vite handle other chunks automatically
+						return undefined;
 					},
 					chunkFileNames: process.env.NODE_ENV === 'production' ? '[hash:8].js' : '[name]-[hash:8].js',
 					assetFileNames: process.env.NODE_ENV === 'production' ? '[hash:8][extname]' : '[name]-[hash:8][extname]',

--- a/packages/misskey-js/package.json
+++ b/packages/misskey-js/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "misskey-js",
-	"version": "2024.10.1014+upstream.2024.10.1",
+	"version": "2024.10.1015+upstream.2024.10.1",
 	"description": "Misskey SDK for JavaScript",
 	"license": "MIT",
 	"main": "./built/index.js",


### PR DESCRIPTION
## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->


## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
- 後からTurnstileウィジェット等を読み込もうとしても、そのときにはすでに403が返ってくるのでウィジェットが表示できない

## Additional info (optional)
<!-- テスト観点など -->
- appチャンクを指定したが、なぜかappチャンクではなくmisskey-api.ts等と同じチャンクに入っている
- 元々misskey-api.ts等はappチャンクに入っていた
- 今回の操作で何故か分割された
- パフォーマンス的にどうかは分からない
```
# 主要チャンク

## develop-mame:
app-3vPQEBXM.js: 416KB
Dj4Rg8pl.js: 284KB
B7JAc7Lw.js: 116KB

## fix-cf-pre-clearance:
Dxmtyrf-.js: 321KB (misskey-api + cloudflare-challenge等)
Bzb5amAv.js: 284KB
CMK26rTd.js: 116KB
app-rWCpdfl0.js: 107KB
```